### PR TITLE
get ts for sts<0 sw==0

### DIFF
--- a/plugin/smarttabs.vim
+++ b/plugin/smarttabs.vim
@@ -101,6 +101,17 @@ endif
 "
 " endfun
 
+fun! GetSoftTabStop()
+  if exists("b:insidetabs")
+    return (b:insidetabs)
+  elseif (&sts > 0)
+    return &sts
+  elseif (&sw > 0)
+    return &sw
+  else
+    return &ts
+  endif
+endfun
 " Insert a smart tab.
 fun! s:InsertSmartTab()
   " Clear the status
@@ -114,7 +125,7 @@ fun! s:InsertSmartTab()
     return "\<Tab>"
   endif
 
-  let sts=exists("b:insidetabs")?(b:insidetabs):((&sts==0)?&sw:&sts)
+  let sts=GetSoftTabStop()
   let sp=(virtcol('.') % sts)
   if sp==0 | let sp=sts | endif
   return strpart("                  ",0,1+sts-sp)
@@ -147,7 +158,7 @@ fun! s:DoSmartDelete()
   if lastchar != ' ' | return ((&digraph)?("\<BS>".lastchar): '')  | endif  " Delete non space at end / Maintain digraphs
 
   " Work out how many tabs to use
-  let sts=(exists("b:insidetabs")?(b:insidetabs):((&sts==0)?(&sw):(&sts)))
+  let sts=GetSoftTabStop()
 
   let ovc=virtcol('.')              " Find where we are
   let sp=(ovc % sts)                " How many virtual characters to delete


### PR DESCRIPTION
I have the following in my vimrc
```
set tabstop=4
set shiftwidth=0
set softtabstop=-1
```

According to help 'sts' 
```
	When 'sts' is negative, the value of 'shiftwidth' is used. [...]
```
and help 'sw':
```
        When zero the 'ts' value will be used.
```

This should mean that these settings are allowed and should set softtabstop == shiftwidth == tabstop == 4 
without having to set each explicitly.

But with those settings smarttab inserts just a single space when pressing tab
after a non white-space character instead of up to 4. This PR fixes that.

I opted for a function since three nested conditional operators would be a bit much.

Vimscript is still a confusing mess of a language to me,
so feel free to change suggest something cleaner.