### PR TITLE
Add help file for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ With the bang (!) at the end, the command also strips trailing  whitespace.
 
 ## Installation:
 
-### With Patogen:
+### With Pathogen:
 
 ```sh
 mkdir -p ~/.vim/bundle && cd ~/.vim/bundle && git clone https://github.com/dpc/vim-smarttabs.git

--- a/README.md
+++ b/README.md
@@ -35,9 +35,22 @@ With the bang (!) at the end, the command also strips trailing  whitespace.
 
 ### With Patogen:
 
-	mkdir -p ~/.vim/bundle && cd ~/.vim/bundle && git clone https://github.com/dpc/vim-smarttabs.git
+```sh
+mkdir -p ~/.vim/bundle && cd ~/.vim/bundle && git clone https://github.com/dpc/vim-smarttabs.git
+```
+
+Then run `:Helptags` from within vim to add helptags for the documentation.
+
+### Using vim-plug:
+
+Add this to your `init.vim` or `.vimrc`:
+```vim
+Plug 'dpc/vim-smarttabs'
+```
+
+Then run `:PlugInstall` from within vim.
 
 ### Manually:
 
-Just copy `smarttabs.vim` into `~/.vim/plugin`.
-
+Just copy `smarttabs.vim` into `~/.vim/plugin`. Notice that this will not
+install the documentation.

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -28,16 +28,6 @@ This script allows you to use your normal tab settings for the beginning of
 the line, and have tabs expanded as spaces anywhere else. This effectively
 distinguishes indent from alignment.
 
-- <tab> Uses editor tab settings to insert a tab at the beginning of the line
-  (before the first non-space character), and inserts spaces otherwise.
-- <BS> Uses editor tab settings to delete tabs or expanded tabs ala smarttab
-
-`:RetabIndent[!] [tabstop]` - This is similar to the `:retab` command, with
-the exception that it affects all and only whitespace at the start of the
-line, changing it to suit your current (or new) 'tabstop' and 'expandtab'
-setting.  With the bang (!) at the end, the command also strips trailing
-whitespace.
-
 ==============================================================================
 INSTALLATION                                          *smarttabs-installation*
 

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -37,6 +37,7 @@ With Pathogen~
 
 Then run `:Helptags` from within vim to add helptags for the documentation.
 
+
 Using vim-plug~
 
 Add this to your `init.vim` or `.vimrc`: >
@@ -47,6 +48,7 @@ And run: >
 
   :PlugInstall
 
+
 Manually~
 
 Just copy `smarttabs.vim` into `~/.vim/plugin`. Notice that this will not
@@ -54,7 +56,6 @@ install the documentation.
 
 ==============================================================================
 CONFIGURATION                                        *smarttabs-configuration*
-
 
 *g:ctab_filetype_maps*
   set this to true if script used as a filetype plugin
@@ -99,7 +100,6 @@ Normal mode maps~
 ==============================================================================
 FUNCTIONS                                                *smarttabs-functions*
 
-                                                                *:RetabIndent*
 `:RetabIndent[!] [tabstop]`
   This is similar to the :retab command, with the exception that it affects
   all and only whitespace at the start of the line, changing it to suit your

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -73,7 +73,7 @@ CONFIGURATION                                        *smarttabs-configuration*
   set this to true to disable re-check of alignment
 
 *g:ctab_enable_default_filetype_maps*
-  disable the filetype specific maps
+  disable the filetype specific maps, see |smarttabs-comment-mappings|.
 
 *g:ctab_disable_tab_maps*
   disable the (original) tab mappings
@@ -81,12 +81,24 @@ CONFIGURATION                                        *smarttabs-configuration*
 ==============================================================================
 MAPPINGS                                                  *smarttabs-mappings*
 
-By default, <tab> (in insert mode) is mapped to insert tabs only if all
-preceding characters are whitespace and <BS> is mapped to use the editor tab
-settings to delete tabs or expand tabs ala smarttab. This can be disabled by
-setting |g:ctab_disable_tab_maps| to any value other than "false".
+Insert mode maps~
 
-	*Todo	expand on <m-;>, <m-s-;>, o, O, <CR> and = mapping
+By default, <tab> is mapped to insert tabs only if all preceding characters
+are whitespace and <BS> is mapped to use the editor tab settings to delete
+tabs or expand tabs ala smarttab. This can be disabled by setting
+|g:ctab_disable_tab_maps| to any value other than "false".
+
+                                                  *smarttabs-comment-mappings*
+When |ctab_enable_default_filetype_maps| is set (and not to "false"), the
+following maps are generated for `cpp`, `c` and `idl` filetypes:
+
+META-;       will start a comment at column 20.
+META-SHIFT-; will start a comment at column 30. 
+
+For `cpp` and `idl` files, a `//` is used for the comments. For `c` files,
+a `/*  */` comment is used.
+
+	*Todo	expand on o, O, <CR> and = mapping
 
 ==============================================================================
 FUNCTIONS                                                *smarttabs-functions*

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -66,7 +66,7 @@ CONFIGURATION                                        *smarttabs-configuration*
   disable the filetype specific maps, see |smarttabs-comment-mappings|.
 
 *g:ctab_disable_tab_maps*
-  disable the (original) tab mappings
+  disable the (original) tab mappings, see |smarttabs-mappings|.
 
 ==============================================================================
 MAPPINGS                                                  *smarttabs-mappings*
@@ -88,7 +88,13 @@ META-SHIFT-; will start a comment at column 30.
 For `cpp` and `idl` files, a `//` is used for the comments. For `c` files,
 a `/*  */` comment is used.
 
-	*Todo	expand on o, O, <CR> and = mapping
+
+<CR> is remapped to ues the smart tabbing style.
+
+
+Normal mode maps~
+
+<o>, <O>, and {=} are remapped to reflect the smart tabbing style.
 
 ==============================================================================
 FUNCTIONS                                                *smarttabs-functions*

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -86,9 +86,6 @@ setting |g:ctab_disable_tab_maps| to any value other than "false".
 	*Todo	expand on <m-;>, <m-s-;>, o, O, <CR> and = mapping
 
 ==============================================================================
-LICENSE                                                    *smarttabs-license*
-
-==============================================================================
 FUNCTIONS                                                *smarttabs-functions*
 
                                                                 *:RetabIndent*

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -1,0 +1,131 @@
+*smarttabs.txt* Plugin to use tab for indentation and space for alignment
+
+Version: 0.0.1
+
+==============================================================================
+CONTENTS                                                  *smarttabs-contents*
+
+    1. Introduction .......................... |smarttabs-introduction|
+    2. Installation .......................... |smarttabs-installation|
+    3. Configuration ......................... |smarttabs-configuration|
+    4. Mappings .............................. |smarttabs-mappings|
+    5. Functions ............................. |smarttabs-functions|
+    6. Changelog ............................. |smarttabs-changelog|
+
+==============================================================================
+INTRODUCTION                                          *smarttabs-introduction*
+
+There are many different arguments about tabs and stuff. My current personal
+preference is a choice of tabbing that is independent of anybody's viewing
+setting.
+
+For the beginning of the line, this means we can use which will expand
+whatever the reader wants it to. Trying to line up tabs at the end of the line
+is a little trickier, and making a few assumptions, my preference is to use
+spaces there.
+
+This script allows you to use your normal tab settings for the beginning of
+the line, and have tabs expanded as spaces anywhere else. This effectively
+distinguishes indent from alignment.
+
+- <tab> Uses editor tab settings to insert a tab at the beginning of the line
+  (before the first non-space character), and inserts spaces otherwise.
+- <BS> Uses editor tab settings to delete tabs or expanded tabs ala smarttab
+
+`:RetabIndent[!] [tabstop]` - This is similar to the `:retab` command, with
+the exception that it affects all and only whitespace at the start of the
+line, changing it to suit your current (or new) 'tabstop' and 'expandtab'
+setting.  With the bang (!) at the end, the command also strips trailing
+whitespace.
+
+==============================================================================
+INSTALLATION                                          *smarttabs-installation*
+
+With Patogen~
+>
+  mkdir -p ~/.vim/bundle && cd ~/.vim/bundle && git clone https://github.com/dpc/vim-smarttabs.git
+
+Using vim-plug~
+
+Add this to your `init.vim` or `.vimrc`: >
+
+  Plug 'dpc/vim-smarttabs'
+
+And run: >
+
+  :PlugInstall
+
+Manually~
+
+Just copy `smarttabs.vim` into `~/.vim/plugin`.
+
+==============================================================================
+CONFIGURATION                                        *smarttabs-configuration*
+
+
+*g:ctab_filetype_maps*
+  set this to true if script used as a filetype plugin
+
+*g:ctab_disable_checkalign*
+  set this to true to disable re-check of alignment
+
+*g:ctab_enable_default_filetype_maps*
+  disable the filetype specific maps
+
+*g:ctab_disable_tab_maps*
+  disable the (original) tab mappings
+
+==============================================================================
+MAPPINGS                                                  *smarttabs-mappings*
+
+By default, <tab> (in insert mode) is mapped to insert tabs only if all
+preceding characters are whitespace and <BS> is mapped to use the editor tab
+settings to delete tabs or expand tabs ala smarttab. This can be disabled by
+setting |g:ctab_disable_tab_maps| to any value other than "false".
+
+	*Todo	expand on <m-;>, <m-s-;>, o, O, <CR> and = mapping
+
+==============================================================================
+LICENSE                                                    *smarttabs-license*
+
+==============================================================================
+FUNCTIONS                                                *smarttabs-functions*
+
+                                                                *:RetabIndent*
+`:RetabIndent[!] [tabstop]`
+  This is similar to the :retab command, with the exception that it affects
+  all and only whitespace at the start of the line, changing it to suit your
+  current (or new) tabstop and expandtab setting.  With the bang (!) at the
+  end, the command also strips trailing whitespace.
+
+                                                                 *CTabAlignTo*
+`CTabAlignTo(n)`
+  'Tab' to the n'th column from the start of the indent.
+
+==============================================================================
+CHANGELOG                                                *smarttabs-changelog*
+
+1.0: - Added `:RetabIndent` command - similar to `:retab,` but doesn't cause
+       internal tabs to be modified.
+1.1: - Added support for backspacing over spaced tabs 'smarttab' style
+     - Clean up the look of it by blanking the `:call`
+     - No longer a 'filetype' plugin by default.
+1.2: - Interactions with 'smarttab' were causing problems. Now fall back to
+       vim's 'smarttab' setting when inserting 'indent' tabs.
+     - Fixed compat with digraphs (which were getting swallowed)
+     - Made <BS> mapping work with the 'filetype' plugin mode.
+     - Make `CTabAlignTo()` public.
+1.3: - Fix removing trailing spaces with `:RetabIndent!` which was causing
+       initial indents to disappear.
+1.4: - Fixed Backspace tab being off by 1
+2.0: - Add support for alignment whitespace for mismatched brackets to be spaces.
+2.1: - Fix = operator
+2.3: - Fix (Gene Smith) for error with non C files
+     - Add option for filetype maps
+     - Allow for lisp indentation
+2.4: - Fix bug in Retab
+2.5: - Fix issue with <CR> not aligning
+2.6: - Fix issue with alignment not disappearing.
+
+==============================================================================
+ vim:tw=78:ts=8:ft=help:norl:

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -97,7 +97,7 @@ FUNCTIONS                                                *smarttabs-functions*
 `:RetabIndent[!] [tabstop]`
   This is similar to the :retab command, with the exception that it affects
   all and only whitespace at the start of the line, changing it to suit your
-  current (or new) tabstop and expandtab setting.  With the bang (!) at the
+  current (or new) 'tabstop' and 'expandtab' setting. With the bang (!) at the
   end, the command also strips trailing whitespace.
 
                                                                  *CTabAlignTo*

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -41,7 +41,7 @@ whitespace.
 ==============================================================================
 INSTALLATION                                          *smarttabs-installation*
 
-With Patogen~
+With Pathogen~
 >
   mkdir -p ~/.vim/bundle && cd ~/.vim/bundle && git clone https://github.com/dpc/vim-smarttabs.git
 

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -45,6 +45,8 @@ With Patogen~
 >
   mkdir -p ~/.vim/bundle && cd ~/.vim/bundle && git clone https://github.com/dpc/vim-smarttabs.git
 
+Then run `:Helptags` from within vim to add helptags for the documentation.
+
 Using vim-plug~
 
 Add this to your `init.vim` or `.vimrc`: >
@@ -57,7 +59,8 @@ And run: >
 
 Manually~
 
-Just copy `smarttabs.vim` into `~/.vim/plugin`.
+Just copy `smarttabs.vim` into `~/.vim/plugin`. Notice that this will not
+install the documentation.
 
 ==============================================================================
 CONFIGURATION                                        *smarttabs-configuration*

--- a/doc/smarttabs.txt
+++ b/doc/smarttabs.txt
@@ -8,7 +8,7 @@ CONTENTS                                                  *smarttabs-contents*
     1. Introduction .......................... |smarttabs-introduction|
     2. Installation .......................... |smarttabs-installation|
     3. Configuration ......................... |smarttabs-configuration|
-    4. Mappings .............................. |smarttabs-mappings|
+    4. Maps .................................. |smarttabs-maps|
     5. Functions ............................. |smarttabs-functions|
     6. Changelog ............................. |smarttabs-changelog|
 
@@ -63,13 +63,13 @@ CONFIGURATION                                        *smarttabs-configuration*
   set this to true to disable re-check of alignment
 
 *g:ctab_enable_default_filetype_maps*
-  disable the filetype specific maps, see |smarttabs-comment-mappings|.
+  disable the filetype specific maps, see |smarttabs-comment-maps|.
 
 *g:ctab_disable_tab_maps*
-  disable the (original) tab mappings, see |smarttabs-mappings|.
+  disable the (original) tab maps, see |smarttabs-maps|.
 
 ==============================================================================
-MAPPINGS                                                  *smarttabs-mappings*
+MAPS                                                          *smarttabs-maps*
 
 Insert mode maps~
 
@@ -78,7 +78,7 @@ are whitespace and <BS> is mapped to use the editor tab settings to delete
 tabs or expand tabs ala smarttab. This can be disabled by setting
 |g:ctab_disable_tab_maps| to any value other than "false".
 
-                                                  *smarttabs-comment-mappings*
+                                                      *smarttabs-comment-maps*
 When |ctab_enable_default_filetype_maps| is set (and not to "false"), the
 following maps are generated for `cpp`, `c` and `idl` filetypes:
 


### PR DESCRIPTION
I thought the plugin was lacking in documentation and want to create a help file. Though the current help file isn't fully finished yet, I decided to create a draft pull request so that comments can already be made.